### PR TITLE
Fixed Deadlining

### DIFF
--- a/src/main/java/frc/robot/commands/DriveCommands.java
+++ b/src/main/java/frc/robot/commands/DriveCommands.java
@@ -166,9 +166,9 @@ public class DriveCommands {
         yController.reset();
         thetaController.reset();
 
-        xController.setTolerance(Units.inchesToMeters(0.1));
-        yController.setTolerance(Units.inchesToMeters(0.1));
-        thetaController.setTolerance(Units.degreesToRadians(1));
+        xController.setTolerance(Units.inchesToMeters(0.5));
+        yController.setTolerance(Units.inchesToMeters(0.5));
+        thetaController.setTolerance(Units.degreesToRadians(2));
 
         return Commands.run(
                         () -> {

--- a/src/main/java/frc/robot/commands/SuperstructureCommands.java
+++ b/src/main/java/frc/robot/commands/SuperstructureCommands.java
@@ -9,42 +9,42 @@ public class SuperstructureCommands {
 
     public static Command scoreRightL4Sim(Drive drive, SwerveDriveSimulation driveSimulation) {
         return Commands.sequence(
-                Commands.deadline(Commands.waitSeconds(1), DriveCommands.alignToReef(drive, false)),
+                Commands.race(Commands.waitSeconds(1), DriveCommands.alignToReef(drive, false)),
                 Commands.waitSeconds(0.1),
                 IntakeCommands.scoreL4Sim(driveSimulation));
     }
 
     public static Command scoreLeftL4Sim(Drive drive, SwerveDriveSimulation driveSimulation) {
         return Commands.sequence(
-                Commands.deadline(Commands.waitSeconds(1), DriveCommands.alignToReef(drive, true)),
+                Commands.race(Commands.waitSeconds(1), DriveCommands.alignToReef(drive, true)),
                 Commands.waitSeconds(0.1),
                 IntakeCommands.scoreL4Sim(driveSimulation));
     }
 
     public static Command scoreRightL3Sim(Drive drive, SwerveDriveSimulation driveSimulation) {
         return Commands.sequence(
-                Commands.deadline(Commands.waitSeconds(1), DriveCommands.alignToReef(drive, false)),
+                Commands.race(Commands.waitSeconds(1), DriveCommands.alignToReef(drive, false)),
                 Commands.waitSeconds(0.1),
                 IntakeCommands.scoreL3Sim(driveSimulation));
     }
 
     public static Command scoreLeftL3Sim(Drive drive, SwerveDriveSimulation driveSimulation) {
         return Commands.sequence(
-                Commands.deadline(Commands.waitSeconds(1), DriveCommands.alignToReef(drive, true)),
+                Commands.race(Commands.waitSeconds(1), DriveCommands.alignToReef(drive, true)),
                 Commands.waitSeconds(0.1),
                 IntakeCommands.scoreL3Sim(driveSimulation));
     }
 
     public static Command scoreRightL2Sim(Drive drive, SwerveDriveSimulation driveSimulation) {
         return Commands.sequence(
-                Commands.deadline(Commands.waitSeconds(1), DriveCommands.alignToReef(drive, false)),
+                Commands.race(Commands.waitSeconds(1), DriveCommands.alignToReef(drive, false)),
                 Commands.waitSeconds(0.1),
                 IntakeCommands.scoreL2Sim(driveSimulation));
     }
 
     public static Command scoreLeftL2Sim(Drive drive, SwerveDriveSimulation driveSimulation) {
         return Commands.sequence(
-                Commands.deadline(Commands.waitSeconds(1), DriveCommands.alignToReef(drive, true)),
+                Commands.race(Commands.waitSeconds(1), DriveCommands.alignToReef(drive, true)),
                 Commands.waitSeconds(0.1),
                 IntakeCommands.scoreL2Sim(driveSimulation));
     }


### PR DESCRIPTION
Redid the scoring sequences to use race parallel commands, as opposed to deadline parallel commands. This means that the robot now shoots when it's auto aligned, even if the one second timer isn't done yet. The one second timer still cuts the auto align short though, which is useful in the event that the robot does not recognize that it is aligned. The auto align cutoff also helps with the issue of the robot turning off sideways for no reason when it is aligning. I also loosened the tolerances on the auto align to be what they originally were for Calypso.